### PR TITLE
Product update

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@emotion/styled": "10.0.27",
     "@sentry/browser": "5.12.1",
     "@sentry/node": "5.12.3",
-    "@unly/ra-data-graphql-prisma": "1.0.0-beta.2",
+    "@unly/ra-data-graphql-prisma": "1.0.0-beta.3",
     "@unly/universal-language-detector": "2.0.3",
     "@unly/utils": "1.0.3",
     "@unly/utils-simple-logger": "1.4.0",

--- a/src/components/admin/ProductEdit.tsx
+++ b/src/components/admin/ProductEdit.tsx
@@ -9,7 +9,9 @@ const ProductEdit = (props): JSX.Element => {
     <Edit {...props}>
       {/* XXX Using custom toolbar breaks updates because props get injected to the DOM instead of being passed down to children, somehow*/}
       {/*<SimpleForm toolbar={<ProductEditToolbar />}>*/}
-      <SimpleForm>
+      <SimpleForm
+        redirect={false}
+      >
         <ArrayInput source="images">
           <SimpleFormIterator>
             <ImageField source="url" label="Image" title="fileName" />

--- a/src/components/admin/ProductEdit.tsx
+++ b/src/components/admin/ProductEdit.tsx
@@ -7,7 +7,9 @@ const ProductEdit = (props): JSX.Element => {
   console.log('productEdit props', props);
   return (
     <Edit {...props}>
-      <SimpleForm toolbar={<ProductEditToolbar />}>
+      {/* XXX Using custom toolbar breaks updates because props get injected to the DOM instead of being passed down to children, somehow*/}
+      {/*<SimpleForm toolbar={<ProductEditToolbar />}>*/}
+      <SimpleForm>
         <ArrayInput source="images">
           <SimpleFormIterator>
             <ImageField source="url" label="Image" title="fileName" />
@@ -24,6 +26,8 @@ const ProductEdit = (props): JSX.Element => {
         {/*</ReferenceArrayInput>*/}
         <TextInput source="titleEN" label={'Title (EN)'} />
         <TextInput source="titleFR" label={'Title (FR)'} />
+        <TextInput source="descriptionEN" label={'Description (EN)'} multiline={true} />
+        <TextInput source="descriptionFR" label={'Description (FR)'} multiline={true} />
         <NumberInput source="price" />
         {/*<TextInput source="description" />*/}
       </SimpleForm>

--- a/src/components/admin/ProductEditToolbar.tsx
+++ b/src/components/admin/ProductEditToolbar.tsx
@@ -14,7 +14,7 @@ const ProductEditToolbar = (props) => {
       {
         record.status === 'PUBLISHED' && (
           <div>
-            <a href={'https://nrn-customer1.now.sh/'}>Published content</a> has been restricted (because we use them to showcase <a href={'https://github.com/UnlyEd/next-right-now'}>NRN</a>) - Create your own post to play around with it
+            <a href={'https://nrn-customer1.now.sh/'} target={'_blank'}>Published content</a> has been restricted (because we use them to showcase <a href={'https://github.com/UnlyEd/next-right-now'} target={'_blank'}>NRN</a>) - Create your own products to play around with it
           </div>
         )
       }

--- a/src/gql/fragments/product.ts
+++ b/src/gql/fragments/product.ts
@@ -8,11 +8,10 @@ export const product = {
       status
       createdAt
       updatedAt
-      title
       titleFR: title(locale: FR)
       titleEN: title(locale: EN)
-      #        description: description(locale: FR)
-      #        descriptionFR: description(locale: FR)
+      descriptionFR: description(locale: FR)
+      descriptionEN: description(locale: EN)
       price
       customer {
         id

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -57,11 +57,9 @@ class Home extends Component<{}, {
     });
 
     const dataProvider = await buildGraphQLProvider({
-      // @ts-ignore
       client,
-      // @ts-ignore
       buildQuery: enhanceBuildQuery(buildQuery),
-      debug: true,
+      debug: process.env.APP_STAGE !== 'production',
     });
     this.setState({
       dataProvider,

--- a/src/utils/graphcms.ts
+++ b/src/utils/graphcms.ts
@@ -1,3 +1,4 @@
+import { IntrospectionResult } from '@unly/ra-data-graphql-prisma/lib/constants/interfaces';
 import { diff, DiffEdit } from 'deep-diff';
 import { FieldNode, IntrospectionField } from 'graphql';
 import { print } from 'graphql/language/printer';
@@ -5,7 +6,6 @@ import endsWith from 'lodash.endswith';
 import get from 'lodash.get';
 import includes from 'lodash.includes';
 import map from 'lodash.map';
-import { IntrospectionResult } from '@unly/ra-data-graphql-prisma/lib/constants/interfaces';
 import { CREATE, UPDATE } from 'react-admin';
 
 import overriddenQueries from '../queries';
@@ -195,7 +195,7 @@ export const enhanceBuildQuery = (buildQuery) => (introspectionResults: Introspe
       // Add i18n data back, because they were removed by the query builder (because they didn't match any known field)
       map(params.data, (value: any, fieldName: string) => {
         if (isLocalisedField(fieldName)) {
-          if(!variables.data){
+          if (!variables.data) {
             variables.data = {};
           }
           variables.data[fieldName] = value;

--- a/src/utils/graphcms.ts
+++ b/src/utils/graphcms.ts
@@ -195,6 +195,9 @@ export const enhanceBuildQuery = (buildQuery) => (introspectionResults: Introspe
       // Add i18n data back, because they were removed by the query builder (because they didn't match any known field)
       map(params.data, (value: any, fieldName: string) => {
         if (isLocalisedField(fieldName)) {
+          if(!variables.data){
+            variables.data = {};
+          }
           variables.data[fieldName] = value;
         }
       });

--- a/src/utils/graphcms.ts
+++ b/src/utils/graphcms.ts
@@ -5,7 +5,7 @@ import endsWith from 'lodash.endswith';
 import get from 'lodash.get';
 import includes from 'lodash.includes';
 import map from 'lodash.map';
-import { IntrospectionResult } from '@unly/ra-data-graphql-prisma/dist/constants/interfaces';
+import { IntrospectionResult } from '@unly/ra-data-graphql-prisma/lib/constants/interfaces';
 import { CREATE, UPDATE } from 'react-admin';
 
 import overriddenQueries from '../queries';

--- a/src/utils/graphcms.ts
+++ b/src/utils/graphcms.ts
@@ -68,20 +68,20 @@ export const getLocalisedFieldAlias = (fieldName: string): string => {
  * See https://github.com/marcantoine/@unly/ra-data-graphql-prisma/pull/12#issuecomment-596074907
  *
  * @param field
- * @param key Field name
- * @param acc Accumulator
- * @param introspectionResults
+ * @param fieldName
+ * @param acc Accumulator (other fields)
+ * @param introspectionResults GraphQL introspection results
  */
 export const fieldAliasResolver = (
   field: IntrospectionField,
-  key: string,
+  fieldName: string,
   acc: FieldNode[],
   introspectionResults: IntrospectionResult,
 ): string => {
-  if (isLocalisedField(key)) {
-    return getLocalisedFieldAlias(key);
+  if (isLocalisedField(fieldName)) {
+    return getLocalisedFieldAlias(fieldName);
   }
-  return key;
+  return fieldName;
 };
 
 /**
@@ -187,25 +187,6 @@ export const enhanceBuildQuery = (buildQuery) => (introspectionResults: Introspe
     fragment,
   );
   const { query, variables } = builtQuery;
-
-  // Step 2 - Sanitize data so that the executed query/mutation contains the expected variables
-  switch (fetchType) {
-    case UPDATE:
-    case CREATE:
-      // Add i18n data back, because they were removed by the query builder (because they didn't match any known field)
-      map(params.data, (value: any, fieldName: string) => {
-        if (isLocalisedField(fieldName)) {
-          if (!variables.data) {
-            variables.data = {};
-          }
-          variables.data[fieldName] = value;
-        }
-      });
-
-      break;
-    default:
-      break;
-  }
 
   console.log('builtQuery', builtQuery);
   console.debug(print(query), '- Variables:', variables, ' using params:', params);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2079,15 +2079,15 @@
   resolved "https://registry.yarnpkg.com/@unly/iso3166-1/-/iso3166-1-1.0.2.tgz#ef1504b4aa6e618b800c14a77261a6c5e9449fa0"
   integrity sha512-aL/7cmcfjpwOaKFr9XHcWP/Z7lQjKLm5NMcjncT96aeSJxfblmPLnH/8lnX0GrWWFA2/CseCxnA73u5eiZcClA==
 
-"@unly/ra-data-graphql-prisma@1.0.0-beta.2":
-  version "1.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@unly/ra-data-graphql-prisma/-/ra-data-graphql-prisma-1.0.0-beta.2.tgz#cc2f2239f1bce40483620780df369a67f02bf956"
-  integrity sha512-PYmc3Ax/Fvd128ySzVwB/tia24M+GGWr9J6WSHpeyEyL0YOWR7ucDzC8w6OMvnePKTIUXnRmD8vlQmCpg7IMtQ==
+"@unly/ra-data-graphql-prisma@1.0.0-beta.3":
+  version "1.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@unly/ra-data-graphql-prisma/-/ra-data-graphql-prisma-1.0.0-beta.3.tgz#bd745374e3e3faaa3d61fa2133a75f36a8d047e1"
+  integrity sha512-peZrQ4wrsBWXzEGUyRVbcjO7PwHy+GZuZRc+8fMT6jpX171rP3/1Y4UmaCPK19dxXgiFVk1Rfm8InH6Hrk+ZpQ==
   dependencies:
-    graphql-tag "2.9.2"
-    lodash "4.17.10"
-    pluralize "7.0.0"
-    ra-data-graphql "2.3.0"
+    graphql-tag "2.10.3"
+    lodash "4.17.15"
+    pluralize "8.0.0"
+    ra-data-graphql "3.2.2"
 
 "@unly/universal-language-detector@2.0.3":
   version "2.0.3"
@@ -2529,7 +2529,7 @@ apollo-cache@1.3.4, apollo-cache@^1.3.4:
     apollo-utilities "^1.3.3"
     tslib "^1.10.0"
 
-apollo-client-preset@^1.0.6:
+apollo-client-preset@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/apollo-client-preset/-/apollo-client-preset-1.0.8.tgz#23bd7176849d0d815f12c648774d009b258a449e"
   integrity sha512-vRrdBfoOBkSboUmkec/zDWK9dT22GoZ2NgTKxfPXaTRh82HGDejDAblMr7BuDtZQ6zxMUiD9kghmO+3HXsHKdQ==
@@ -2540,7 +2540,7 @@ apollo-client-preset@^1.0.6:
     apollo-link-http "^1.3.1"
     graphql-tag "^2.4.2"
 
-apollo-client@2.6.8, apollo-client@^2.2.2, apollo-client@^2.2.8, apollo-client@^2.6.7:
+apollo-client@2.6.8, apollo-client@^2.2.2, apollo-client@^2.6.3, apollo-client@^2.6.7:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/apollo-client/-/apollo-client-2.6.8.tgz#01cebc18692abf90c6b3806414e081696b0fa537"
   integrity sha512-0zvJtAcONiozpa5z5zgou83iEKkBaXhhSSXJebFHRXs100SecDojyUWKjwTtBPn9HbM6o5xrvC5mo9VQ5fgAjw==
@@ -3830,7 +3830,7 @@ conf@5.0.0:
     pkg-up "^3.0.1"
     write-file-atomic "^3.0.0"
 
-connected-react-router@6.7.0, connected-react-router@^6.5.2:
+connected-react-router@^6.5.2:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/connected-react-router/-/connected-react-router-6.7.0.tgz#1c37a65684f1729533264c1b1903ee91c8ca3a15"
   integrity sha512-RDmcmiwSfUWQ3U7J7RVkc9cwNtek26fUn0DWpA8pS7JylC97VNeosrsIxjJ/3CGDrzZPqnc0Hr/kZxjh75JGlw==
@@ -5347,7 +5347,7 @@ final-form-arrays@^3.0.1:
   resolved "https://registry.yarnpkg.com/final-form-arrays/-/final-form-arrays-3.0.2.tgz#9f3bef778dec61432357744eb6f3abef7e7f3847"
   integrity sha512-TfO8aZNz3RrsZCDx8GHMQcyztDNpGxSSi9w4wpSNKlmv2PfFWVVM8P7Yj5tj4n0OWax+x5YwTLhT5BnqSlCi+w==
 
-final-form@4.18.7, final-form@^4.18.5:
+final-form@^4.18.5:
   version "4.18.7"
   resolved "https://registry.yarnpkg.com/final-form/-/final-form-4.18.7.tgz#c30239ac9154cbfbf4f6d19e831f5fc9cbc1ba78"
   integrity sha512-XdlYYGDcoUcKKVzRJxLg8N/ZG3wVLZvhO7K7PKQWVMjCiIUWdmtBwApw2NFS4P7RJvg8OdF73qGXhhE3K5PuDQ==
@@ -5705,12 +5705,7 @@ graphql-tag@2.10.2:
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.2.tgz#e42214d0dde29e8db5d55b0107efdb2d461ed270"
   integrity sha512-7rUuJkVGyedBiVJ/hPaxndDnzxANUZ+QhTu0KUzgTGtP3ibY/hSUl9em21aVh5BNMJsmMc4nVuOTBoiAUJ2xBQ==
 
-graphql-tag@2.9.2:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.9.2.tgz#2f60a5a981375f430bf1e6e95992427dc18af686"
-  integrity sha512-qnNmof9pAqj/LUzs3lStP0Gw1qhdVCUS7Ab7+SUB6KD5aX1uqxWQRwMnOGTkhKuLvLNIs1TvNz+iS9kUGl1MhA==
-
-graphql-tag@^2.4.2, graphql-tag@^2.6.1:
+graphql-tag@2.10.3, graphql-tag@^2.10.1, graphql-tag@^2.4.2:
   version "2.10.3"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.3.tgz#ea1baba5eb8fc6339e4c4cf049dabe522b0edf03"
   integrity sha512-4FOv3ZKfA4WdOKJeHdz6B3F/vxBLSgmBcGeAFPf4n1F64ltJUvOOerNj0rsJxONQGdhUMynQIvd6LzB+1J5oKA==
@@ -7533,11 +7528,6 @@ lodash.xorby@4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.xorby/-/lodash.xorby-4.7.0.tgz#9c19a6f9f063a6eb53dd03c1b6871799801463d7"
   integrity sha1-nBmm+fBjputT3QPBtocXmYAUY9c=
 
-lodash@4.17.10:
-  version "4.17.10"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
-  integrity sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==
-
 lodash@4.17.15, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@~4.17.5:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
@@ -8801,7 +8791,12 @@ pkg-up@^3.0.1:
   dependencies:
     find-up "^3.0.0"
 
-pluralize@7.0.0, pluralize@~7.0.0:
+pluralize@8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
+  integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
+
+pluralize@~7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
   integrity sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==
@@ -9455,22 +9450,6 @@ querystring@0.2.0, querystring@^0.2.0:
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
-ra-core@3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/ra-core/-/ra-core-3.3.0.tgz#5da4b2059c46eeaf59154fd475374e7a5e213dd8"
-  integrity sha512-D/Yp9PeMiaa6xKinbBH2cmy/G+Bkj1LMM5auRjG6qkoXc8U6oiqOmY2M4ZCO8LH7Kwujr5tyeW7gj3oU6c0hgg==
-  dependencies:
-    "@testing-library/react" "^8.0.7"
-    classnames "~2.2.5"
-    date-fns "^1.29.0"
-    eventemitter3 "^3.0.0"
-    inflection "~1.12.0"
-    lodash "~4.17.5"
-    prop-types "^15.6.1"
-    query-string "^5.1.1"
-    recompose "~0.26.0"
-    reselect "~3.0.0"
-
 ra-core@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/ra-core/-/ra-core-3.2.4.tgz#5d3fcf46be8bd05eea3767cc092748f401e1aedb"
@@ -9487,14 +9466,14 @@ ra-core@^3.2.4:
     recompose "~0.26.0"
     reselect "~3.0.0"
 
-ra-data-graphql@2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/ra-data-graphql/-/ra-data-graphql-2.3.0.tgz#49cdad50bd6d98fd1ffe34aa196a3846ba424591"
-  integrity sha512-ASPamJYkl159LoYcyCbEuZ+W4/lssVCNfWfMp5FgLmkqrPBVCi5Kkf90I8cH+EktxBWtvrfjZmk5rJhlkNnd+g==
+ra-data-graphql@3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/ra-data-graphql/-/ra-data-graphql-3.2.2.tgz#19ad698eb8343fefb5a54cfa5c9c5923d5437c74"
+  integrity sha512-zPyd+vwL2ItMtqXydQyIn4EbUmFqICeWJPspQpYAe8qrY3/ImSIT3AZKjcyMZ71hHqqmRPOcIpJrJqBIr63C1Q==
   dependencies:
-    apollo-client "^2.2.8"
-    apollo-client-preset "^1.0.6"
-    graphql-tag "^2.6.1"
+    apollo-client "^2.6.3"
+    apollo-client-preset "^1.0.8"
+    graphql-tag "^2.10.1"
     lodash "~4.17.5"
     pluralize "~7.0.0"
 
@@ -9628,7 +9607,7 @@ react-final-form-arrays@^3.1.1:
   dependencies:
     "@babel/runtime" "^7.4.5"
 
-react-final-form@6.3.5, react-final-form@^6.3.3:
+react-final-form@^6.3.3:
   version "6.3.5"
   resolved "https://registry.yarnpkg.com/react-final-form/-/react-final-form-6.3.5.tgz#772781071d26d26493b0c8ef4f97f76f06fc1c0f"
   integrity sha512-btqEp1+n1WO4bUDopBdvUoIuoGHf91n/EOJg0QU5YjhX9CK+4RIsBI0M41lmyT3H6hWv6NELdX5n5zBJyOIXoA==
@@ -9651,7 +9630,7 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-redux@7.2.0, react-redux@^7.1.0:
+react-redux@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.0.tgz#f970f62192b3981642fec46fd0db18a074fe879d"
   integrity sha512-EvCAZYGfOLqwV7gh849xy9/pt55rJXPwmYvI4lilPM5rUT/1NxuuN59ipdBksRVSvz0KInbPnp4IfoXJXCqiDA==
@@ -9662,7 +9641,7 @@ react-redux@7.2.0, react-redux@^7.1.0:
     prop-types "^15.7.2"
     react-is "^16.9.0"
 
-react-router-dom@5.1.2, react-router-dom@^5.1.0:
+react-router-dom@^5.1.0:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.1.2.tgz#06701b834352f44d37fbb6311f870f84c76b9c18"
   integrity sha512-7BPHAaIwWpZS074UKaw1FjVdZBSVWEk8IuDXdB+OkLb8vd/WRQIpA4ag9WQk61aEfQs47wHyjWUoUGGZxpQXew==
@@ -9820,14 +9799,14 @@ recompose@~0.26.0:
     hoist-non-react-statics "^2.3.1"
     symbol-observable "^1.0.4"
 
-redux-saga@1.1.3, redux-saga@^1.0.0:
+redux-saga@^1.0.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/redux-saga/-/redux-saga-1.1.3.tgz#9f3e6aebd3c994bbc0f6901a625f9a42b51d1112"
   integrity sha512-RkSn/z0mwaSa5/xH/hQLo8gNf4tlvT18qXDNvedihLcfzh+jMchDgaariQoehCpgRltEm4zHKJyINEz6aqswTw==
   dependencies:
     "@redux-saga/core" "^1.1.3"
 
-redux@4.0.5, "redux@^3.7.2 || ^4.0.3", redux@^4.0.4:
+"redux@^3.7.2 || ^4.0.3", redux@^4.0.4:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.5.tgz#4db5de5816e17891de8a80c424232d06f051d93f"
   integrity sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3830,7 +3830,7 @@ conf@5.0.0:
     pkg-up "^3.0.1"
     write-file-atomic "^3.0.0"
 
-connected-react-router@^6.5.2:
+connected-react-router@6.7.0, connected-react-router@^6.5.2:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/connected-react-router/-/connected-react-router-6.7.0.tgz#1c37a65684f1729533264c1b1903ee91c8ca3a15"
   integrity sha512-RDmcmiwSfUWQ3U7J7RVkc9cwNtek26fUn0DWpA8pS7JylC97VNeosrsIxjJ/3CGDrzZPqnc0Hr/kZxjh75JGlw==
@@ -5347,7 +5347,7 @@ final-form-arrays@^3.0.1:
   resolved "https://registry.yarnpkg.com/final-form-arrays/-/final-form-arrays-3.0.2.tgz#9f3bef778dec61432357744eb6f3abef7e7f3847"
   integrity sha512-TfO8aZNz3RrsZCDx8GHMQcyztDNpGxSSi9w4wpSNKlmv2PfFWVVM8P7Yj5tj4n0OWax+x5YwTLhT5BnqSlCi+w==
 
-final-form@^4.18.5:
+final-form@4.18.7, final-form@^4.18.5:
   version "4.18.7"
   resolved "https://registry.yarnpkg.com/final-form/-/final-form-4.18.7.tgz#c30239ac9154cbfbf4f6d19e831f5fc9cbc1ba78"
   integrity sha512-XdlYYGDcoUcKKVzRJxLg8N/ZG3wVLZvhO7K7PKQWVMjCiIUWdmtBwApw2NFS4P7RJvg8OdF73qGXhhE3K5PuDQ==
@@ -9455,6 +9455,22 @@ querystring@0.2.0, querystring@^0.2.0:
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
+ra-core@3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/ra-core/-/ra-core-3.3.0.tgz#5da4b2059c46eeaf59154fd475374e7a5e213dd8"
+  integrity sha512-D/Yp9PeMiaa6xKinbBH2cmy/G+Bkj1LMM5auRjG6qkoXc8U6oiqOmY2M4ZCO8LH7Kwujr5tyeW7gj3oU6c0hgg==
+  dependencies:
+    "@testing-library/react" "^8.0.7"
+    classnames "~2.2.5"
+    date-fns "^1.29.0"
+    eventemitter3 "^3.0.0"
+    inflection "~1.12.0"
+    lodash "~4.17.5"
+    prop-types "^15.6.1"
+    query-string "^5.1.1"
+    recompose "~0.26.0"
+    reselect "~3.0.0"
+
 ra-core@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/ra-core/-/ra-core-3.2.4.tgz#5d3fcf46be8bd05eea3767cc092748f401e1aedb"
@@ -9612,7 +9628,7 @@ react-final-form-arrays@^3.1.1:
   dependencies:
     "@babel/runtime" "^7.4.5"
 
-react-final-form@^6.3.3:
+react-final-form@6.3.5, react-final-form@^6.3.3:
   version "6.3.5"
   resolved "https://registry.yarnpkg.com/react-final-form/-/react-final-form-6.3.5.tgz#772781071d26d26493b0c8ef4f97f76f06fc1c0f"
   integrity sha512-btqEp1+n1WO4bUDopBdvUoIuoGHf91n/EOJg0QU5YjhX9CK+4RIsBI0M41lmyT3H6hWv6NELdX5n5zBJyOIXoA==
@@ -9635,7 +9651,7 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-redux@^7.1.0:
+react-redux@7.2.0, react-redux@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.0.tgz#f970f62192b3981642fec46fd0db18a074fe879d"
   integrity sha512-EvCAZYGfOLqwV7gh849xy9/pt55rJXPwmYvI4lilPM5rUT/1NxuuN59ipdBksRVSvz0KInbPnp4IfoXJXCqiDA==
@@ -9646,7 +9662,7 @@ react-redux@^7.1.0:
     prop-types "^15.7.2"
     react-is "^16.9.0"
 
-react-router-dom@^5.1.0:
+react-router-dom@5.1.2, react-router-dom@^5.1.0:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.1.2.tgz#06701b834352f44d37fbb6311f870f84c76b9c18"
   integrity sha512-7BPHAaIwWpZS074UKaw1FjVdZBSVWEk8IuDXdB+OkLb8vd/WRQIpA4ag9WQk61aEfQs47wHyjWUoUGGZxpQXew==
@@ -9804,14 +9820,14 @@ recompose@~0.26.0:
     hoist-non-react-statics "^2.3.1"
     symbol-observable "^1.0.4"
 
-redux-saga@^1.0.0:
+redux-saga@1.1.3, redux-saga@^1.0.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/redux-saga/-/redux-saga-1.1.3.tgz#9f3e6aebd3c994bbc0f6901a625f9a42b51d1112"
   integrity sha512-RkSn/z0mwaSa5/xH/hQLo8gNf4tlvT18qXDNvedihLcfzh+jMchDgaariQoehCpgRltEm4zHKJyINEz6aqswTw==
   dependencies:
     "@redux-saga/core" "^1.1.3"
 
-"redux@^3.7.2 || ^4.0.3", redux@^4.0.4:
+redux@4.0.5, "redux@^3.7.2 || ^4.0.3", redux@^4.0.4:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.5.tgz#4db5de5816e17891de8a80c424232d06f051d93f"
   integrity sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==


### PR DESCRIPTION
Fixes #9

# Roadmap

- [x] Fix updates when only localised fields are updated. When only localised fields are updated, the query is stripped from `data` because no data were sent to the `buildQuery` function, which considered there wasn't any data to update